### PR TITLE
Updating Symfony bundle documentation link

### DIFF
--- a/integration.md
+++ b/integration.md
@@ -38,7 +38,7 @@ Symfony ServiceContainer is then available in your spec files and you just have 
 ### Atom
 
 You can now develop your kahlan tests in Atom with autocompletion thanks to [atom-kahlan](https://github.com/elephantly/atom-kahlan).
-Just go in your favorite editor's settings and install the package. Enjoy :)
+Just go in your favorite editor's settings and install the package. 
 
 ### Phalcon
 

--- a/integration.md
+++ b/integration.md
@@ -35,6 +35,11 @@ To import all Laravel "test facilities" into Kahlan you can make use of [this de
 To use Kahlan in a Symfony 2.7+ environment, you can use [elephantly/kahlan-bundle](https://packagist.org/packages/elephantly/kahlan-bundle) ([GitHub link](https://github.com/elephantly/kahlan-bundle)).
 Symfony ServiceContainer is then available in your spec files and you just have to launch `php app/console kahlan:run` with usual options.
 
+### Atom
+
+You can now develop your kahlan tests in Atom with autocompletion thanks to [atom-kahlan](https://github.com/elephantly/atom-kahlan).
+Just go in your favorite editor's settings and install the package. Enjoy :)
+
 ### Phalcon
 
 When a class extends a built-in class (i.e. a non PHP class) it's not possible to stub parent class methods since they are not in PHP userland.

--- a/integration.md
+++ b/integration.md
@@ -32,7 +32,7 @@ To import all Laravel "test facilities" into Kahlan you can make use of [this de
 
 ### Symfony
 
-To use Kahlan in a Symfony 2.7+ environment, you can use [elephantly/kahlan-bundle](https://packagist.org/packages/elephantly/kahlan-bundle) ([GitHub link](https://github.com/elephantly/kahlan-bundle)).
+To use Kahlan in a Symfony 2.7+ environment, you can use [elephantly/kahlan-bundle](https://packagist.org/packages/elephantly/kahlan-bundle) ([GitHub documentation](https://elephantly.github.io/kahlan-bundle/)).
 Symfony ServiceContainer is then available in your spec files and you just have to launch `php app/console kahlan:run` with usual options.
 
 ### Atom


### PR DESCRIPTION
We generated a GitHub Pages doc for Kahlan-Bundle, and so would like to change the link in Kahlan's doc